### PR TITLE
Lower max_upload_rate to 10 MB/sec

### DIFF
--- a/herd/BitTornado/download_bt1.py
+++ b/herd/BitTornado/download_bt1.py
@@ -110,7 +110,7 @@ defaults = [
         'number of peers at which to stop initiating new connections'),
     ('check_hashes', 1,
         'whether to check hashes on disk'),
-    ('max_upload_rate', 30000,
+    ('max_upload_rate', 10000,
         'maximum kB/s to upload at (0 = no limit, -1 = automatic)'),
     ('max_download_rate', 0,
         'maximum kB/s to download at (0 = no limit)'),


### PR DESCRIPTION
 - Change `max_upload_rate` from 30 to 10 MB/sec

@vinted/sre

Trying to reduce webs traffic spikes even more. If this does not help, I'll try to adjust `max_download_rate` as well.