### PR TITLE
Change to python-2.5 or later relative paths

### DIFF
--- a/herd/BitTornado/BT1/Choker.py
+++ b/herd/BitTornado/BT1/Choker.py
@@ -2,7 +2,7 @@
 # see LICENSE.txt for license information
 
 from random import randrange, shuffle
-from herd.BitTornado.clock import clock
+from .. clock import clock
 try:
     True
 except:

--- a/herd/BitTornado/BT1/Connecter.py
+++ b/herd/BitTornado/BT1/Connecter.py
@@ -1,8 +1,8 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.bitfield import Bitfield
-from herd.BitTornado.clock import clock
+from .. bitfield import Bitfield
+from .. clock import clock
 from binascii import b2a_hex
 
 try:

--- a/herd/BitTornado/BT1/Downloader.py
+++ b/herd/BitTornado/BT1/Downloader.py
@@ -1,10 +1,10 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.CurrentRateMeasure import Measure
-from herd.BitTornado.bitfield import Bitfield
+from .. CurrentRateMeasure import Measure
+from .. bitfield import Bitfield
 from random import shuffle
-from herd.BitTornado.clock import clock
+from .. clock import clock
 try:
     True
 except:

--- a/herd/BitTornado/BT1/HTTPDownloader.py
+++ b/herd/BitTornado/BT1/HTTPDownloader.py
@@ -1,13 +1,13 @@
 # Written by John Hoffman
 # see LICENSE.txt for license information
 
-from herd.BitTornado.CurrentRateMeasure import Measure
+from .. CurrentRateMeasure import Measure
 from random import randint
 from urlparse import urlparse
 from httplib import HTTPConnection
 from urllib import quote
 from threading import Thread
-from herd.BitTornado.__init__ import product_name,version_short
+from .. __init__ import product_name,version_short
 try:
     True
 except:

--- a/herd/BitTornado/BT1/PiecePicker.py
+++ b/herd/BitTornado/BT1/PiecePicker.py
@@ -2,7 +2,7 @@
 # see LICENSE.txt for license information
 
 from random import randrange, shuffle
-from herd.BitTornado.clock import clock
+from .. clock import clock
 try:
     True
 except:

--- a/herd/BitTornado/BT1/Rerequester.py
+++ b/herd/BitTornado/BT1/Rerequester.py
@@ -2,11 +2,11 @@
 # modified for multitracker operation by John Hoffman
 # see LICENSE.txt for license information
 
-from herd.BitTornado.zurllib import urlopen, quote
+from .. zurllib import urlopen, quote
 from urlparse import urlparse, urlunparse
 from socket import gethostbyname
 from btformats import check_peers
-from herd.BitTornado.bencode import bdecode
+from .. bencode import bdecode
 from threading import Thread, Lock
 from cStringIO import StringIO
 from traceback import print_exc

--- a/herd/BitTornado/BT1/Storage.py
+++ b/herd/BitTornado/BT1/Storage.py
@@ -1,7 +1,7 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.piecebuffer import BufferPool
+from .. piecebuffer import BufferPool
 from threading import Lock
 from time import time, strftime, localtime
 import os

--- a/herd/BitTornado/BT1/StorageWrapper.py
+++ b/herd/BitTornado/BT1/StorageWrapper.py
@@ -1,12 +1,12 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.bitfield import Bitfield
+from .. bitfield import Bitfield
 try:
     from hashlib import sha1 as sha
 except ImportError:
     from sha import sha
-from herd.BitTornado.clock import clock
+from .. clock import clock
 from traceback import print_exc
 from random import randrange
 try:

--- a/herd/BitTornado/BT1/Uploader.py
+++ b/herd/BitTornado/BT1/Uploader.py
@@ -1,7 +1,7 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.CurrentRateMeasure import Measure
+from .. CurrentRateMeasure import Measure
 
 try:
     True

--- a/herd/BitTornado/BT1/makemetafile.py
+++ b/herd/BitTornado/BT1/makemetafile.py
@@ -10,7 +10,7 @@ except ImportError:
     from sha import sha
 from copy import copy
 from string import strip
-from herd.BitTornado.bencode import bencode
+from .. bencode import bencode
 from btformats import check_info
 from threading import Event
 from time import time

--- a/herd/BitTornado/BT1/track.py
+++ b/herd/BitTornado/BT1/track.py
@@ -1,18 +1,18 @@
 # Written by Bram Cohen
 # see LICENSE.txt for license information
 
-from herd.BitTornado.parseargs import parseargs, formatDefinitions
-from herd.BitTornado.RawServer import RawServer, autodetect_ipv6, autodetect_socket_style
-from herd.BitTornado.HTTPHandler import HTTPHandler, months, weekdays
-from herd.BitTornado.parsedir import parsedir
+from .. parseargs import parseargs, formatDefinitions
+from .. RawServer import RawServer, autodetect_ipv6, autodetect_socket_style
+from .. HTTPHandler import HTTPHandler, months, weekdays
+from .. parsedir import parsedir
 from NatCheck import NatCheck
 from T2T import T2TList
-from herd.BitTornado.subnetparse import IP_List, ipv6_to_ipv4, to_ipv4, is_valid_ip, is_ipv4
-from herd.BitTornado.iprangeparse import IP_List as IP_Range_List
-from herd.BitTornado.torrentlistparse import parsetorrentlist
+from .. subnetparse import IP_List, ipv6_to_ipv4, to_ipv4, is_valid_ip, is_ipv4
+from .. iprangeparse import IP_List as IP_Range_List
+from .. torrentlistparse import parsetorrentlist
 from threading import Event, Thread
-from herd.BitTornado.bencode import bencode, bdecode, Bencached
-from herd.BitTornado.zurllib import urlopen, quote, unquote
+from .. bencode import bencode, bdecode, Bencached
+from .. zurllib import urlopen, quote, unquote
 from Filter import Filter
 from urlparse import urlparse
 from os import rename, getpid
@@ -20,7 +20,7 @@ from os.path import exists, isfile
 from cStringIO import StringIO
 from traceback import print_exc
 from time import time, gmtime, strftime, localtime
-from herd.BitTornado.clock import clock
+from .. clock import clock
 from random import shuffle, seed, randrange
 try:
     from hashlib import sha1 as sha
@@ -32,8 +32,8 @@ from string import lower
 import sys, os
 import signal
 import re
-import herd.BitTornado.__init__
-from herd.BitTornado.__init__ import version, createPeerID
+#import .. __init__
+from .. __init__ import version, createPeerID
 try:
     True
 except:


### PR DESCRIPTION
Herd clients failed loading modules:

```
  File "herd/murder_client.py", line 22, in <module>
    from BitTornado.download_bt1 import (
  File "herd/BitTornado/download_bt1.py", line 7, in <module>
    from BT1.Choker import Choker
  File "herd/BitTornado/BT1/Choker.py", line 5, in <module>
    from herd.BitTornado.clock import clock
  File "herd/herd.py", line 13, in <module>
    import BitTornado.BT1.track as bttrack
  File "herd/BitTornado/BT1/track.py", line 11, in <module>
    from T2T import T2TList
  File "herd/BitTornado/BT1/T2T.py", line 4, in <module>
    from Rerequester import Rerequester
  File "herd/BitTornado/BT1/Rerequester.py", line 5, in <module>
    from herd.BitTornado.zurllib import urlopen, quote
```

Fortunately, there is a fix for that at russss/Herd#29 though it hasn't been merged to the original project.

This PR applies the fix to our fork.

@vinted/sre