### PR TITLE
Lower max_upload_rate to 0.5 MB/sec

### DIFF
--- a/herd/BitTornado/download_bt1.py
+++ b/herd/BitTornado/download_bt1.py
@@ -110,7 +110,7 @@ defaults = [
         'number of peers at which to stop initiating new connections'),
     ('check_hashes', 1,
         'whether to check hashes on disk'),
-    ('max_upload_rate', 10000,
+    ('max_upload_rate', 500,
         'maximum kB/s to upload at (0 = no limit, -1 = automatic)'),
     ('max_download_rate', 0,
         'maximum kB/s to download at (0 = no limit)'),


### PR DESCRIPTION
@vinted/sre

Seems that lowering the upload rate does not affect build times at all.

This is the last attempt on changing upload rates. If it does not make any difference, we'll try to use `max_download_rate`.